### PR TITLE
bind dev server to all interfaces

### DIFF
--- a/{{cookiecutter.project_slug}}/docker-compose.yml
+++ b/{{cookiecutter.project_slug}}/docker-compose.yml
@@ -25,7 +25,7 @@ services:
 
   udata:
     image: udata/udata
-    command: serve
+    command: serve --host=0.0.0.0
     links:
       - mongodb:mongodb
       - redis:redis


### PR DESCRIPTION
This enables access to the udata development server from outside the container .